### PR TITLE
BUG 8288 - Timeseries API: datetime correction to iso format

### DIFF
--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,6 +8,8 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
+from sqlalchemy import func
+
 from . import View
 
 
@@ -38,7 +40,15 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        filter_max = self.session.query(
+            Depthseries.depth,
+            func.max(Depthseries.value).label("max_value")
+    ).group_by(Depthseries.depth).subquery()
+
+        query = self.session.query(Depthseries).join(
+            filter_max,
+            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
+        )
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -6,6 +6,8 @@ from pyramid.view import view_config
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 
+from pyramid_app_caseinterview.views.serialization import DateObject
+
 from . import View
 
 
@@ -23,7 +25,7 @@ class API(View):
         return [
             {
                 "id": str(q.id),
-                "datetime": q.datetime,
+                "datetime": DateObject(q.datetime),
                 "value": q.value,
             }
             for q in query.all()

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,8 +8,6 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
-from sqlalchemy import func
-
 from . import View
 
 
@@ -40,15 +38,7 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        filter_max = self.session.query(
-            Depthseries.depth,
-            func.max(Depthseries.value).label("max_value")
-    ).group_by(Depthseries.depth).subquery()
-
-        query = self.session.query(Depthseries).join(
-            filter_max,
-            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
-        )
+        query = self.session.query(Depthseries)
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/serialization.py
+++ b/pyramid_app_caseinterview/views/serialization.py
@@ -1,0 +1,10 @@
+from pyramid.view import view_config
+import datetime
+
+class DateObject:
+    def __init__(self, datetime_value):
+        self.datetime = datetime_value
+
+    def __json__(self, request):
+        if isinstance(self.datetime, datetime.datetime):
+            return self.datetime.isoformat()


### PR DESCRIPTION
[ BUG 8288 - Timeseries API: Datetime format error ]

[ Problem ]
JSON serialization fails with non-serializable types, such as datetime. Pyramid’s JSON renderer is capable of serializing standard python types but doesn’t handle complex types like datetime out of the box

[Solution ]
Implement a custom serialization mechanism that can handle datetime using ISO Format

[Design ]
A custom serialization module is used for serializing datetime object,
This module could be further used to implement serialization of others complex objects that might be required in the future.

The module would return a string of date time, in ISO 8601 format using isoformat() function.
[BUG 8288.pdf](https://github.com/user-attachments/files/18138598/BUG.8288.pdf)