### PR TITLE
BUG 8289 - Depthseries API: Duplicate Date

### DIFF
--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,6 +8,8 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
+from sqlalchemy import func
+
 from . import View
 
 
@@ -38,7 +40,15 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        filter_max = self.session.query(
+            Depthseries.depth,
+            func.max(Depthseries.value).label("max_value")
+    ).group_by(Depthseries.depth).subquery()
+
+        query = self.session.query(Depthseries).join(
+            filter_max,
+            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
+        )
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -6,6 +6,8 @@ from pyramid.view import view_config
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 
+from pyramid_app_caseinterview.views.serialization import DateObject
+
 from . import View
 
 
@@ -23,7 +25,7 @@ class API(View):
         return [
             {
                 "id": str(q.id),
-                "datetime": q.datetime,
+                "datetime": DateObject(q.datetime),
                 "value": q.value,
             }
             for q in query.all()

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,8 +8,6 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
-from sqlalchemy import func
-
 from . import View
 
 
@@ -40,15 +38,7 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        filter_max = self.session.query(
-            Depthseries.depth,
-            func.max(Depthseries.value).label("max_value")
-    ).group_by(Depthseries.depth).subquery()
-
-        query = self.session.query(Depthseries).join(
-            filter_max,
-            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
-        )
+        query = self.session.query(Depthseries)
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/serialization.py
+++ b/pyramid_app_caseinterview/views/serialization.py
@@ -1,0 +1,10 @@
+from pyramid.view import view_config
+import datetime
+
+class DateObject:
+    def __init__(self, datetime_value):
+        self.datetime = datetime_value
+
+    def __json__(self, request):
+        if isinstance(self.datetime, datetime.datetime):
+            return self.datetime.isoformat()


### PR DESCRIPTION
[ Problem ]
Repeated rows with the same value at certain depth. This is caused by RAW data being returned from database

[Solution ]
1.	Short term fix : 
Remove duplicate data by filtering the records
2.	Long term fix : 
Database quality check, investigate why duplicates exist in the first place.
Adjust the filtering method depending on the business logic and determine which data would be preferred
(such as choosing Max, Min, or Average value between the duplicates).

[ Design ]
Filtering out duplicate records for the same depth. This would be done by keeping only one record per depth 
Since the relation between depth and value is not known, a maximum value is chosen for short term fix. 

[ Implementation ]
Modify query for API view:
1. Create a sub queries to find max value in the “value” column for each depth
2. Then group up the max value by depth making it only take a single max value for each depth.
3. Join with the initial table to include the full form data { Id, Depth, Value }
4. Return { Id, Depth, Value } as JSON without duplicate

[BUG 8289.pdf](https://github.com/user-attachments/files/18138990/BUG.8289.pdf)
