### PR TITLE
BUG 8290 - Depthseries API: Null values

### DIFF
--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,6 +8,8 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
+from sqlalchemy import func
+
 from . import View
 
 
@@ -38,7 +40,15 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        filter_max = self.session.query(
+            Depthseries.depth,
+            func.max(Depthseries.value).label("max_value")
+    ).group_by(Depthseries.depth).subquery()
+
+        query = self.session.query(Depthseries).join(
+            filter_max,
+            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
+        )
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -6,6 +6,8 @@ from pyramid.view import view_config
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 
+from pyramid_app_caseinterview.views.serialization import DateObject
+
 from . import View
 
 
@@ -23,7 +25,7 @@ class API(View):
         return [
             {
                 "id": str(q.id),
-                "datetime": q.datetime,
+                "datetime": DateObject(q.datetime),
                 "value": q.value,
             }
             for q in query.all()

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,8 +8,6 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
-from sqlalchemy import func
-
 from . import View
 
 
@@ -40,15 +38,7 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        filter_max = self.session.query(
-            Depthseries.depth,
-            func.max(Depthseries.value).label("max_value")
-    ).group_by(Depthseries.depth).subquery()
-
-        query = self.session.query(Depthseries).join(
-            filter_max,
-            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
-        )
+        query = self.session.query(Depthseries)
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -48,7 +48,7 @@ class API(View):
         query = self.session.query(Depthseries).join(
             filter_max,
             (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
-        )
+        ).filter(Depthseries.value.isnot(None)) #filter out "null" values
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/serialization.py
+++ b/pyramid_app_caseinterview/views/serialization.py
@@ -1,0 +1,10 @@
+from pyramid.view import view_config
+import datetime
+
+class DateObject:
+    def __init__(self, datetime_value):
+        self.datetime = datetime_value
+
+    def __json__(self, request):
+        if isinstance(self.datetime, datetime.datetime):
+            return self.datetime.isoformat()


### PR DESCRIPTION
[ Problem ]
Null value is found on endpoint API

[ Solution ]
1. Short term : Filtered out Null value
2. Long term : Assign default value to fill null value

Design :
- Short term correspondence, add filter nor "null" value to main query

On the other hand, if Users require a value at certain depths that happens to be filtered out, It would raise another question to why these data doesn’t exist (causes gap in data and may discard useful data). 
- long term fix : Assign default value such as interpolation between two points, mean, median, or mode to replace null value

[BUG 8290.pdf](https://github.com/user-attachments/files/18186673/BUG.8290.pdf)



