### PR TITLE
PRODUCT BACKLOG ITEM 8293 – Depthseries API - Add endpoint to Download Data as CSV

### DIFF
--- a/pyramid_app_caseinterview/routes.py
+++ b/pyramid_app_caseinterview/routes.py
@@ -11,3 +11,4 @@ def includeme(config):
     config.add_route("timeseries", "/api/v1/timeseries")
     config.add_route("depthseries", "/api/v1/depthseries")
     config.add_route("activity", "/api/v1/activity")
+    config.add_route("depthseries_download", "/api/v1/download/depthseries")

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -85,7 +85,7 @@ class API(View):
     @view_config(
         route_name="depthseries_download",
         permission=NO_PERMISSION_REQUIRED,
-        renderer=None,
+        renderer="json",
         request_method="GET",
     )
     def download_depthseries_api(self):
@@ -98,7 +98,9 @@ class API(View):
             if end_depth:
                 end_depth = int(end_depth)
         except ValueError as e:
-            return {"Error": f"Require integer. [{e}]"}
+            return Response(
+                body= f"Error: Input Integers {e}",
+                status=400)
 
         query = self.session.query(Depthseries)
 

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -2,11 +2,14 @@
 
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
+from pyramid.response import Response
 
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
+
+from pyramid_app_caseinterview.views.downloader import stream_csv
 
 from sqlalchemy import func
 from datetime import datetime
@@ -78,3 +81,49 @@ class API(View):
             }
             for q in query.all()
         ]
+    
+    @view_config(
+        route_name="depthseries_download",
+        permission=NO_PERMISSION_REQUIRED,
+        renderer=None,
+        request_method="GET",
+    )
+    def download_depthseries_api(self):
+        start_depth = self.request.params.get("from")
+        end_depth = self.request.params.get("to")
+
+        try:
+            if start_depth:
+                start_depth = int(start_depth)
+            if end_depth:
+                end_depth = int(end_depth)
+        except ValueError as e:
+            return {"Error": f"Require integer. [{e}]"}
+
+        query = self.session.query(Depthseries)
+
+        if start_depth and end_depth:
+            query = query.filter((Depthseries.depth >= start_depth) & (Depthseries.depth <= end_depth))
+        elif start_depth:
+            query = query.filter(Depthseries.depth >= start_depth)
+        elif end_depth:
+            query = query.filter(Depthseries.depth <= end_depth)
+
+        filter_max = self.session.query(
+            Depthseries.depth,
+            func.max(Depthseries.value).label("max_value")
+        ).group_by(Depthseries.depth).subquery()
+
+        query = query.join(
+            filter_max,
+            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
+        ).filter(Depthseries.value.isnot(None))
+
+        response = Response(
+            app_iter=stream_csv(query, Depthseries),
+            content_type="text/csv",
+            headers={
+                "Content-Disposition": "attachment; filename=depthseries.csv"
+            }
+        )
+        return response

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,6 +8,8 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
+from sqlalchemy import func
+
 from . import View
 
 
@@ -38,7 +40,15 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        filter_max = self.session.query(
+            Depthseries.depth,
+            func.max(Depthseries.value).label("max_value")
+    ).group_by(Depthseries.depth).subquery()
+
+        query = self.session.query(Depthseries).join(
+            filter_max,
+            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
+        )
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -6,6 +6,8 @@ from pyramid.view import view_config
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 
+from pyramid_app_caseinterview.views.serialization import DateObject
+
 from . import View
 
 
@@ -23,7 +25,7 @@ class API(View):
         return [
             {
                 "id": str(q.id),
-                "datetime": q.datetime,
+                "datetime": DateObject(q.datetime),
                 "value": q.value,
             }
             for q in query.all()

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -9,6 +9,7 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 from pyramid_app_caseinterview.views.serialization import DateObject
 
 from sqlalchemy import func
+from datetime import datetime
 
 from . import View
 
@@ -23,7 +24,27 @@ class API(View):
         request_method="GET",
     )
     def timeseries_api(self):
-        query = self.session.query(Timeseries)
+        start_date = self.request.params.get("from")
+        end_date = self.request.params.get("to")
+
+        try:
+            if start_date:
+                start_date =datetime.strptime(start_date, "%Y-%m-%d")
+            if end_date:
+                end_date =datetime.strptime(end_date, "%Y-%m-%d")
+        except ValueError:
+            return {"Error" : "Invalid date format. use YYYY-MM-DD."}
+        
+        
+        if start_date and end_date:
+            query = query.filter((Timeseries.datetime >= start_date) & (Timeseries.datetime <= end_date))
+        if start_date:
+            query = query.filter((Timeseries.datetime >= start_date))
+        if end_date:
+            query = query.filter((Timeseries.datetime <= end_date)) 
+        else:
+            query = self.session.query(Timeseries)
+
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,8 +8,6 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
-from sqlalchemy import func
-
 from . import View
 
 
@@ -40,15 +38,7 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        filter_max = self.session.query(
-            Depthseries.depth,
-            func.max(Depthseries.value).label("max_value")
-    ).group_by(Depthseries.depth).subquery()
-
-        query = self.session.query(Depthseries).join(
-            filter_max,
-            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
-        )
+        query = self.session.query(Depthseries)
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -48,7 +48,7 @@ class API(View):
         query = self.session.query(Depthseries).join(
             filter_max,
             (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
-        )
+        ).filter(Depthseries.value.isnot(None)) #filter out "null" values
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/downloader.py
+++ b/pyramid_app_caseinterview/views/downloader.py
@@ -1,0 +1,12 @@
+from sqlalchemy.inspection import inspect
+
+def stream_csv(query, model):
+    """Stream CSV data for download."""
+
+    columns = [column.key for column in inspect(model).columns]
+    header_row = ",".join(columns) + "\n"
+    yield header_row.encode("utf-8")
+
+    for q in query.yield_per(1000): 
+        row = [str(getattr(q, column)) for column in columns]
+        yield (",".join(row) + "\n").encode("utf-8")

--- a/pyramid_app_caseinterview/views/serialization.py
+++ b/pyramid_app_caseinterview/views/serialization.py
@@ -1,0 +1,10 @@
+from pyramid.view import view_config
+import datetime
+
+class DateObject:
+    def __init__(self, datetime_value):
+        self.datetime = datetime_value
+
+    def __json__(self, request):
+        if isinstance(self.datetime, datetime.datetime):
+            return self.datetime.isoformat()


### PR DESCRIPTION
[ Requirement]
1. Allow input parameter to filter depth range for user (similar to Timeseries Backlog 8292)
2. Endpoint response is to download depthseries data in CSV format

[ Design ]
1. Create module "Downloader"
- Downloader module should be able to inspect columns in database, allowing it to adapt to different data, make it possible to download CSV of other APIs if needed in the future.
- implement a streamline to download CSV in chunks without loading everything at once, to anticipate memory issues in case of large data.
2. Implement input query parameters logic similar to Backlog 8292 Timeseries API
- Input query is normalize to only accept integer value

[ Implementation ]
1. Configure additional route for new endpoint : /api/v1/download/depthseries
2. Create new endpoint API depthseries_download
3. Simillar logic to Backlog 8292 for query parameter is implemented
4. Validate query parameters into integer, if not -> return error to user
5. Generate response using downloader (stream to CSV)
6. Return depthseries CSV output

[ Downloader Implementation]
1. Endpoint API call downloader 
2. The first yield from downloader is headers [Id, Depth, Value]
3. Second yield continuously yield row by row data ( 1000 row at a times )

[ API Test ]
> /api/v1/download/depthseries	
> /api/v1/download/depthseries?from=30
>/api/v1/download/depthseries?from=30&to=500	
>/api/v1/download/depthseries?to=500	
>/api/v1/download/depthseries?from=one	

[Backlog 8293.pdf](https://github.com/user-attachments/files/18153689/BUG.8293.pdf)