### PR TITLE
PRODUCT BACKLOG ITEM 8292 – Timeseries API: Add tests

### DIFF
--- a/pyramid_app_caseinterview/routes.py
+++ b/pyramid_app_caseinterview/routes.py
@@ -11,3 +11,4 @@ def includeme(config):
     config.add_route("timeseries", "/api/v1/timeseries")
     config.add_route("depthseries", "/api/v1/depthseries")
     config.add_route("activity", "/api/v1/activity")
+    config.add_route("depthseries_download", "/api/v1/download/depthseries")

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -85,7 +85,7 @@ class API(View):
     @view_config(
         route_name="depthseries_download",
         permission=NO_PERMISSION_REQUIRED,
-        renderer=None,
+        renderer="json",
         request_method="GET",
     )
     def download_depthseries_api(self):
@@ -98,7 +98,9 @@ class API(View):
             if end_depth:
                 end_depth = int(end_depth)
         except ValueError as e:
-            return {"Error": f"Require integer. [{e}]"}
+            return Response(
+                body= f"Error: Input Integers {e}",
+                status=400)
 
         query = self.session.query(Depthseries)
 

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -2,11 +2,14 @@
 
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
+from pyramid.response import Response
 
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
+
+from pyramid_app_caseinterview.views.downloader import stream_csv
 
 from sqlalchemy import func
 from datetime import datetime
@@ -78,3 +81,49 @@ class API(View):
             }
             for q in query.all()
         ]
+    
+    @view_config(
+        route_name="depthseries_download",
+        permission=NO_PERMISSION_REQUIRED,
+        renderer=None,
+        request_method="GET",
+    )
+    def download_depthseries_api(self):
+        start_depth = self.request.params.get("from")
+        end_depth = self.request.params.get("to")
+
+        try:
+            if start_depth:
+                start_depth = int(start_depth)
+            if end_depth:
+                end_depth = int(end_depth)
+        except ValueError as e:
+            return {"Error": f"Require integer. [{e}]"}
+
+        query = self.session.query(Depthseries)
+
+        if start_depth and end_depth:
+            query = query.filter((Depthseries.depth >= start_depth) & (Depthseries.depth <= end_depth))
+        elif start_depth:
+            query = query.filter(Depthseries.depth >= start_depth)
+        elif end_depth:
+            query = query.filter(Depthseries.depth <= end_depth)
+
+        filter_max = self.session.query(
+            Depthseries.depth,
+            func.max(Depthseries.value).label("max_value")
+        ).group_by(Depthseries.depth).subquery()
+
+        query = query.join(
+            filter_max,
+            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
+        ).filter(Depthseries.value.isnot(None))
+
+        response = Response(
+            app_iter=stream_csv(query, Depthseries),
+            content_type="text/csv",
+            headers={
+                "Content-Disposition": "attachment; filename=depthseries.csv"
+            }
+        )
+        return response

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,6 +8,8 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
+from sqlalchemy import func
+
 from . import View
 
 
@@ -38,7 +40,15 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        filter_max = self.session.query(
+            Depthseries.depth,
+            func.max(Depthseries.value).label("max_value")
+    ).group_by(Depthseries.depth).subquery()
+
+        query = self.session.query(Depthseries).join(
+            filter_max,
+            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
+        )
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -6,6 +6,8 @@ from pyramid.view import view_config
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
 
+from pyramid_app_caseinterview.views.serialization import DateObject
+
 from . import View
 
 
@@ -23,7 +25,7 @@ class API(View):
         return [
             {
                 "id": str(q.id),
-                "datetime": q.datetime,
+                "datetime": DateObject(q.datetime),
                 "value": q.value,
             }
             for q in query.all()

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -38,6 +38,7 @@ class API(View):
         except ValueError:
             return {"Error" : "Invalid date format. use YYYY-MM-DD."}
         
+        query = self.session.query(Timeseries)
         
         if start_date and end_date:
             query = query.filter((Timeseries.datetime >= start_date) & (Timeseries.datetime <= end_date))
@@ -45,8 +46,6 @@ class API(View):
             query = query.filter((Timeseries.datetime >= start_date))
         if end_date:
             query = query.filter((Timeseries.datetime <= end_date)) 
-        else:
-            query = self.session.query(Timeseries)
 
         return [
             {

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -9,6 +9,7 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 from pyramid_app_caseinterview.views.serialization import DateObject
 
 from sqlalchemy import func
+from datetime import datetime
 
 from . import View
 
@@ -23,7 +24,27 @@ class API(View):
         request_method="GET",
     )
     def timeseries_api(self):
-        query = self.session.query(Timeseries)
+        start_date = self.request.params.get("from")
+        end_date = self.request.params.get("to")
+
+        try:
+            if start_date:
+                start_date =datetime.strptime(start_date, "%Y-%m-%d")
+            if end_date:
+                end_date =datetime.strptime(end_date, "%Y-%m-%d")
+        except ValueError:
+            return {"Error" : "Invalid date format. use YYYY-MM-DD."}
+        
+        
+        if start_date and end_date:
+            query = query.filter((Timeseries.datetime >= start_date) & (Timeseries.datetime <= end_date))
+        if start_date:
+            query = query.filter((Timeseries.datetime >= start_date))
+        if end_date:
+            query = query.filter((Timeseries.datetime <= end_date)) 
+        else:
+            query = self.session.query(Timeseries)
+
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -8,8 +8,6 @@ from pyramid_app_caseinterview.models.timeseries import Timeseries
 
 from pyramid_app_caseinterview.views.serialization import DateObject
 
-from sqlalchemy import func
-
 from . import View
 
 
@@ -40,15 +38,7 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        filter_max = self.session.query(
-            Depthseries.depth,
-            func.max(Depthseries.value).label("max_value")
-    ).group_by(Depthseries.depth).subquery()
-
-        query = self.session.query(Depthseries).join(
-            filter_max,
-            (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
-        )
+        query = self.session.query(Depthseries)
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -48,7 +48,7 @@ class API(View):
         query = self.session.query(Depthseries).join(
             filter_max,
             (Depthseries.depth == filter_max.c.depth) & (Depthseries.value == filter_max.c.max_value)
-        )
+        ).filter(Depthseries.value.isnot(None)) #filter out "null" values
         return [
             {
                 "id": str(q.id),

--- a/pyramid_app_caseinterview/views/downloader.py
+++ b/pyramid_app_caseinterview/views/downloader.py
@@ -1,0 +1,12 @@
+from sqlalchemy.inspection import inspect
+
+def stream_csv(query, model):
+    """Stream CSV data for download."""
+
+    columns = [column.key for column in inspect(model).columns]
+    header_row = ",".join(columns) + "\n"
+    yield header_row.encode("utf-8")
+
+    for q in query.yield_per(1000): 
+        row = [str(getattr(q, column)) for column in columns]
+        yield (",".join(row) + "\n").encode("utf-8")

--- a/pyramid_app_caseinterview/views/serialization.py
+++ b/pyramid_app_caseinterview/views/serialization.py
@@ -1,0 +1,10 @@
+from pyramid.view import view_config
+import datetime
+
+class DateObject:
+    def __init__(self, datetime_value):
+        self.datetime = datetime_value
+
+    def __json__(self, request):
+        if isinstance(self.datetime, datetime.datetime):
+            return self.datetime.isoformat()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -6,7 +6,7 @@ import re
 
 from sqlalchemy import func
 from sqlalchemy.orm.session import Session
-
+from datetime import datetime
 
 class TestDatabase:
     def test_version(self, session_tm: Session) -> None:
@@ -15,12 +15,67 @@ class TestDatabase:
 
 
 class TestApp:
-    def test_home(self, testapp) -> None:
-        res = testapp.get("/", status=200)
-        assert b"<h1>caseinterview</h1>" in res.body
-        res = testapp.get("/users/create", status=302).follow()
+    def test_timeseries_api_no_filters(self, testapp, session_tm, populate_timeseries_data):
+        """Test timeseries API endpoint with no filters."""
+        # Call the API without any filters
+        res = testapp.get("/api/v1/timeseries", status=200)
+        # Assertions
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+        assert {"id", "datetime", "value"}.issubset(res.json[0].keys())  # Check keys
 
-    def test_home_admin(self, testapp, as_admin) -> None:
-        res = testapp.get("/", status=200)
-        assert b"User Management" in res.body
-        res = testapp.get("/users/create", status=200)
+    def test_timeseries_api_filters_double(self, testapp, session_tm, populate_timeseries_data):
+        """Test timeseries API endpoint with filters."""
+        # Filter by a specific datetime range (valid filter)
+        start_date = "2022-01-01"
+        end_date = "2024-01-01"
+        # Call the API with the filters
+        res = testapp.get(f"/api/v1/timeseries?from={start_date}&to={end_date}", status=200)
+        # Assertions for valid datetime filters
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+
+        start_datetime = datetime.strptime(start_date, "%Y-%m-%d")
+        end_datetime = datetime.strptime(end_date, "%Y-%m-%d")
+        for item in res.json:
+            item_datetime = datetime.strptime(item["datetime"], "%Y-%m-%dT%H:%M:%S")
+            assert start_datetime <= item_datetime <= end_datetime
+       
+    def test_timeseries_api_filters_single(self, testapp, session_tm, populate_timeseries_data):
+        """Test timeseries API endpoint with filters."""
+        # Filter by a start date
+        start_date = "2022-01-01"
+        # Call the API with the filters
+        res = testapp.get(f"/api/v1/timeseries?from={start_date}", status=200)
+        # Assertions for valid datetime filters
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+
+        start_datetime = datetime.strptime(start_date, "%Y-%m-%d")
+        for item in res.json:
+            item_datetime = datetime.strptime(item["datetime"], "%Y-%m-%dT%H:%M:%S")
+            assert start_datetime <= item_datetime
+
+        # Filter by a end date
+        end_date = "2024-01-01"
+        # Call the API with the filters
+        res = testapp.get(f"/api/v1/timeseries?to={end_date}", status=200)
+        # Assertions for valid datetime filters
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+
+        end_datetime = datetime.strptime(end_date, "%Y-%m-%d")
+        for item in res.json:
+            item_datetime = datetime.strptime(item["datetime"], "%Y-%m-%dT%H:%M:%S")
+            assert item_datetime <= end_datetime
+
+    def test_timeseries_api_filters_invalid(self, testapp, session_tm, populate_timeseries_data):
+        """Test timeseries API endpoint with filters."""
+        # Filter by a start date
+        start_date = "now"
+        # Call the API with the filters
+        res = testapp.get(f"/api/v1/timeseries?from={start_date}", status=200)
+        # Assertions for valid datetime filters
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+        assert {"Error" : "Invalid date format. use YYYY-MM-DD."} == res.json

--- a/tests/testing.ini
+++ b/tests/testing.ini
@@ -22,7 +22,7 @@ pyramid.default_locale_name = en
 # rollbar.branch = master
 # rollbar.root = %(here)s
 
-# sqlalchemy.url = postgresql://postgres:abc@localhost:5432/test
+sqlalchemy.url = postgresql://postgres:abc@caseinterview_database:5432/caseinterview
 datadirectory = faux_data
 
 authentication_provider = ad_only


### PR DESCRIPTION
Add tests for each endpoint
Each test basically only perform these sequence :
1.	Populate timeseries data
2.	Declare query argument for test
3.	Call API endpoint, and passing the argument if any
4.	Normalize query argument into datetime type
5.	Normalize API response into datetime type
6.	Check if response is not empty
7.	Compare query and response depending on the logic for testing (if argument is given)

- Additional correction for run test error on API endpoint query

[Backlog 8292.pdf](https://github.com/user-attachments/files/18180034/Backlog.8292.pdf)
