### PR TITLE
BUG 8290 - Depthseries API: Null values

### DIFF
--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -36,7 +36,7 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        query = self.session.query(Depthseries).filter(Depthseries.value.isnot(None)) #filter out "null" values
         return [
             {
                 "id": str(q.id),


### PR DESCRIPTION
[ Problem ]
Null value is found on endpoint API

[ Solution ]

Short term : Filtered out Null value
Long term : Assign default value to fill null value
Design :

Short term correspondence, add filter nor "null" value to main query
On the other hand, if Users require a value at certain depths that happens to be filtered out, It would raise another question to why these data doesn’t exist (causes gap in data and may discard useful data).

long term fix : Assign default value such as interpolation between two points, mean, median, or mode to replace null value
[BUG 8290.pdf](https://github.com/user-attachments/files/18186673/BUG.8290.pdf)