### PR TITLE
PRODUCT BACKLOG ITEM 8291 – Timeseries API: Add Date Filtering from URL Params

### DIFF
--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -5,9 +5,10 @@ from pyramid.view import view_config
 
 from pyramid_app_caseinterview.models.depthseries import Depthseries
 from pyramid_app_caseinterview.models.timeseries import Timeseries
+from pyramid_app_caseinterview.views.serialization import DateObject
 
 from . import View
-
+from datetime import datetime
 
 class API(View):
     """API endpoints"""
@@ -19,11 +20,30 @@ class API(View):
         request_method="GET",
     )
     def timeseries_api(self):
+        start_date = self.request.params.get("from")
+        end_date = self.request.params.get("to")
+
+        try:
+            if start_date:
+                start_date =datetime.strptime(start_date, "%Y-%m-%d")
+            if end_date:
+                end_date =datetime.strptime(end_date, "%Y-%m-%d")
+        except ValueError:
+            return {"Error" : "Invalid date format. use YYYY-MM-DD."}
+        
         query = self.session.query(Timeseries)
+        
+        if start_date and end_date:
+            query = query.filter((Timeseries.datetime >= start_date) & (Timeseries.datetime <= end_date))
+        if start_date:
+            query = query.filter((Timeseries.datetime >= start_date))
+        if end_date:
+            query = query.filter((Timeseries.datetime <= end_date)) 
+
         return [
             {
                 "id": str(q.id),
-                "datetime": q.datetime,
+                "datetime": DateObject(q.datetime),
                 "value": q.value,
             }
             for q in query.all()

--- a/pyramid_app_caseinterview/views/serialization.py
+++ b/pyramid_app_caseinterview/views/serialization.py
@@ -1,0 +1,10 @@
+from pyramid.view import view_config
+import datetime
+
+class DateObject:
+    def __init__(self, datetime_value):
+        self.datetime = datetime_value
+
+    def __json__(self, request):
+        if isinstance(self.datetime, datetime.datetime):
+            return self.datetime.isoformat()


### PR DESCRIPTION
[ Problem ]
Filtering data based on date ranges

[ Design ]

Get input parameters for {start_date} and {end_date} ( format : YY-MM-DD )
Ensure the initial API endpoint doesn’t break, which means both inputs are made optional
Error handling if the input parameter is incorrect format and inform error response to user
Additionally since both inputs are optional, only either one of those inputs could still be used to filter
[ Implementation ]

Modify API endpoint to receive request params
Normalize string type param into datetime format
Validation if request param is unable to typecasted into datetime format -> return error
Add filters to query -> return JSON based on given params :
[No parameter]: Return all records.
["start_date"&"end_date"]: Return records between two dates
["start_date"]: Return records starting from that start date
["end_date"]: Return records ending on that end date
[API format]

/api/v1/timeseries
/api/v1/timeseries?from=YYYY-MM-DD?&to=YYYY-MM-DD
/api/v1/timeseries?from=YYYY-MM-DD?
/api/v1/timeseries?to=YYYY-MM-DD

[BUG 8291.pdf](https://github.com/user-attachments/files/18140437/BUG.8291.pdf)