### PR TITLE
PRODUCT BACKLOG ITEM 8292 – Timeseries API: Add tests

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -6,7 +6,7 @@ import re
 
 from sqlalchemy import func
 from sqlalchemy.orm.session import Session
-
+from datetime import datetime
 
 class TestDatabase:
     def test_version(self, session_tm: Session) -> None:
@@ -15,12 +15,67 @@ class TestDatabase:
 
 
 class TestApp:
-    def test_home(self, testapp) -> None:
-        res = testapp.get("/", status=200)
-        assert b"<h1>caseinterview</h1>" in res.body
-        res = testapp.get("/users/create", status=302).follow()
+    def test_timeseries_api_no_filters(self, testapp, session_tm, populate_timeseries_data):
+        """Test timeseries API endpoint with no filters."""
+        # Call the API without any filters
+        res = testapp.get("/api/v1/timeseries", status=200)
+        # Assertions
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+        assert {"id", "datetime", "value"}.issubset(res.json[0].keys())  # Check keys
 
-    def test_home_admin(self, testapp, as_admin) -> None:
-        res = testapp.get("/", status=200)
-        assert b"User Management" in res.body
-        res = testapp.get("/users/create", status=200)
+    def test_timeseries_api_filters_double(self, testapp, session_tm, populate_timeseries_data):
+        """Test timeseries API endpoint with filters."""
+        # Filter by a specific datetime range (valid filter)
+        start_date = "2022-01-01"
+        end_date = "2024-01-01"
+        # Call the API with the filters
+        res = testapp.get(f"/api/v1/timeseries?from={start_date}&to={end_date}", status=200)
+        # Assertions for valid datetime filters
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+
+        start_datetime = datetime.strptime(start_date, "%Y-%m-%d")
+        end_datetime = datetime.strptime(end_date, "%Y-%m-%d")
+        for item in res.json:
+            item_datetime = datetime.strptime(item["datetime"], "%Y-%m-%dT%H:%M:%S")
+            assert start_datetime <= item_datetime <= end_datetime
+       
+    def test_timeseries_api_filters_single(self, testapp, session_tm, populate_timeseries_data):
+        """Test timeseries API endpoint with filters."""
+        # Filter by a start date
+        start_date = "2022-01-01"
+        # Call the API with the filters
+        res = testapp.get(f"/api/v1/timeseries?from={start_date}", status=200)
+        # Assertions for valid datetime filters
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+
+        start_datetime = datetime.strptime(start_date, "%Y-%m-%d")
+        for item in res.json:
+            item_datetime = datetime.strptime(item["datetime"], "%Y-%m-%dT%H:%M:%S")
+            assert start_datetime <= item_datetime
+
+        # Filter by a end date
+        end_date = "2024-01-01"
+        # Call the API with the filters
+        res = testapp.get(f"/api/v1/timeseries?to={end_date}", status=200)
+        # Assertions for valid datetime filters
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+
+        end_datetime = datetime.strptime(end_date, "%Y-%m-%d")
+        for item in res.json:
+            item_datetime = datetime.strptime(item["datetime"], "%Y-%m-%dT%H:%M:%S")
+            assert item_datetime <= end_datetime
+
+    def test_timeseries_api_filters_invalid(self, testapp, session_tm, populate_timeseries_data):
+        """Test timeseries API endpoint with filters."""
+        # Filter by a start date
+        start_date = "now"
+        # Call the API with the filters
+        res = testapp.get(f"/api/v1/timeseries?from={start_date}", status=200)
+        # Assertions for valid datetime filters
+        assert res.content_type == "application/json"
+        assert len(res.json) > 0  # Ensure the response contains data
+        assert {"Error" : "Invalid date format. use YYYY-MM-DD."} == res.json

--- a/tests/testing.ini
+++ b/tests/testing.ini
@@ -22,7 +22,7 @@ pyramid.default_locale_name = en
 # rollbar.branch = master
 # rollbar.root = %(here)s
 
-# sqlalchemy.url = postgresql://postgres:abc@localhost:5432/test
+sqlalchemy.url = postgresql://postgres:abc@caseinterview_database:5432/caseinterview
 datadirectory = faux_data
 
 authentication_provider = ad_only


### PR DESCRIPTION
Add tests for each endpoint
Each test basically only perform these sequence :
1.	Populate timeseries data
2.	Declare query argument for test
3.	Call API endpoint, and passing the argument if any
4.	Normalize query argument into datetime type
5.	Normalize API response into datetime type
6.	Check if response is not empty
7.	Compare query and response depending on the logic for testing (if argument is given)

- Additional correction for run test error on API endpoint query

[Backlog 8292.pdf](https://github.com/user-attachments/files/18180034/Backlog.8292.pdf)
