### PR TITLE
 PRODUCT BACKLOG ITEM 8293 – Depthseries API - Add endpoint to Download as CSV

### DIFF
--- a/pyramid_app_caseinterview/views/downloader.py
+++ b/pyramid_app_caseinterview/views/downloader.py
@@ -1,0 +1,12 @@
+from sqlalchemy.inspection import inspect
+
+def stream_csv(query, model):
+    """Stream CSV data for download."""
+
+    columns = [column.key for column in inspect(model).columns]
+    header_row = ",".join(columns) + "\n"
+    yield header_row.encode("utf-8")
+
+    for q in query.yield_per(1000): 
+        row = [str(getattr(q, column)) for column in columns]
+        yield (",".join(row) + "\n").encode("utf-8")


### PR DESCRIPTION
[ Requirement]
1. Allow input parameter to filter depth range for user (similar to Timeseries Backlog 8292)
2. Endpoint response is to download depthseries data in CSV format

[ Design ]
1. Create module "Downloader"
- Downloader module should be able to inspect columns in database, allowing it to adapt to different data, make it possible to download CSV of other APIs if needed in the future.
- implement a streamline to download CSV in chunks without loading everything at once, to anticipate memory issues in case of large data.
2. Implement input query parameters logic similar to Backlog 8292 Timeseries API
- Input query is normalize to only accept integer value

[ Implementation ]
1. Configure additional route for new endpoint : /api/v1/download/depthseries
2. Create new endpoint API depthseries_download
3. Simillar logic to Backlog 8292 for query parameter is implemented
4. Validate query parameters into integer, if not -> return error to user
5. Generate response using downloader (stream to CSV)
6. Return depthseries CSV output

[ Downloader Implementation]
1. Endpoint API call downloader 
2. The first yield from downloader is headers [Id, Depth, Value]
3. Second yield continuously yield row by row data ( 1000 row at a times )

[ API Test ]
> /api/v1/download/depthseries	
> /api/v1/download/depthseries?from=30
>/api/v1/download/depthseries?from=30&to=500	
>/api/v1/download/depthseries?to=500	
>/api/v1/download/depthseries?from=one	

[Backlog 8293.pdf](https://github.com/user-attachments/files/18153689/BUG.8293.pdf)